### PR TITLE
Set scope of zip dependencies to "provided"

### DIFF
--- a/cms-oss-server/pom.xml
+++ b/cms-oss-server/pom.xml
@@ -205,21 +205,25 @@
 			<groupId>com.gentics.cms-oss</groupId>
 			<artifactId>cms-js-lib</artifactId>
 			<type>zip</type>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.gentics.cms-oss</groupId>
 			<artifactId>cms-aloha-bundle</artifactId>
 			<type>zip</type>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.gentics.cms-oss</groupId>
 			<artifactId>admin-ui</artifactId>
 			<type>zip</type>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.gentics.cms-oss</groupId>
 			<artifactId>editor-ui</artifactId>
 			<type>zip</type>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- Test Dependencies -->


### PR DESCRIPTION
so that content is not copied to root folder of .jar