### PR TITLE
GPU-1115: Manually resize page images on publish

### DIFF
--- a/cms-core/src/main/java/com/gentics/contentnode/publish/mesh/WriteTask.java
+++ b/cms-core/src/main/java/com/gentics/contentnode/publish/mesh/WriteTask.java
@@ -15,6 +15,7 @@ import com.gentics.contentnode.publish.PublishQueue.PublishAction;
 import com.gentics.contentnode.publish.cr.TagmapEntryRenderer;
 //import com.gentics.contentnode.publish.mesh.MeshPublisher.MeshNodeTracker;
 import com.gentics.mesh.core.rest.node.FieldMap;
+import com.gentics.mesh.core.rest.node.NodePublishRequest;
 import com.gentics.mesh.core.rest.node.NodeResponse;
 
 import io.reactivex.Single;
@@ -58,6 +59,11 @@ class WriteTask extends AbstractWriteTask {
 	 * Fields of the Mesh Node
 	 */
 	protected FieldMap fields;
+
+	/**
+	 * Optional publish request body
+	 */
+	protected NodePublishRequest nodePublishRequest;
 
 //	/**
 //	 * Tracker to mark when an object was written

--- a/cms-core/src/main/java/com/gentics/contentnode/render/RenderUtils.java
+++ b/cms-core/src/main/java/com/gentics/contentnode/render/RenderUtils.java
@@ -109,7 +109,7 @@ public class RenderUtils {
 						meshNode.setParentNode(new NodeReference().setUuid(MeshPublisher.getMeshUuid(page.getFolder())).setSchema(new SchemaReferenceImpl().setName(mp.getSchemaName(Folder.TYPE_FOLDER))));
 						meshNode.setSchema(new SchemaReferenceImpl().setName(mp.getSchemaName(Page.TYPE_PAGE)));
 						meshNode.setFields(new FieldMapImpl());
-						mp.handleRenderedEntries(true, masterNode.getId(), () -> meshNode.getFields(), mp.render(mp.getEntries(Page.TYPE_PAGE), null, language, false), null, null, null, null);
+						mp.handleRenderedEntries(true, masterNode.getId(), () -> meshNode.getFields(), mp.render(mp.getEntries(Page.TYPE_PAGE), null, language, false), null, null, null, null, null);
 
 						HttpPost postMethod = new HttpPost(getPreviewUrl(previewUrl, getMode(renderMode), node));
 


### PR DESCRIPTION
Since we are aware of the usage of images hosted by the same project, as well as their manipulation properties, we can apply these manipulation in advance on the page publish, to make it being able to restrict the on-demand manipulation, which is resource consuming and is theoretically DDoS prone.