### PR TITLE
SUP-15890: Tagpart corruption

### DIFF
--- a/cms-oss-changelog/src/changelog/entries/2023/10/7583.SUP-15890.bugfix
+++ b/cms-oss-changelog/src/changelog/entries/2023/10/7583.SUP-15890.bugfix
@@ -1,0 +1,1 @@
+Administrator User Interface: An issue with editing Tag-Parts, causing corruption of these has been resolved.

--- a/cms-ui/apps/admin-ui/src/app/features/construct/components/construct-detail/construct-detail.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/construct/components/construct-detail/construct-detail.component.ts
@@ -193,6 +193,10 @@ export class ConstructDetailComponent
             autoEnable: this.fgProperties.value.autoEnable,
         };
 
+        if (payload.categoryId == null) {
+            payload.categoryId = -1;
+        }
+
         return this.operations.update(this.currentEntity.id, payload).pipe(
             detailLoading(this.appState),
             tap((updatedEntity: TagTypeBO<Raw>) => {

--- a/cms-ui/apps/admin-ui/src/app/features/construct/components/construct-part-list/construct-part-list.component.html
+++ b/cms-ui/apps/admin-ui/src/app/features/construct/components/construct-part-list/construct-part-list.component.html
@@ -1,9 +1,14 @@
-<gtx-button
-    *ngIf="allowCreation"
-    size="small"
-    flat="true"
-    (click)="createNewPart()"
-><icon left>add</icon>{{ 'shared.create_new_construct_part' | i18n }}</gtx-button>
+<div class="list-controls">
+    <gtx-button
+        *ngIf="allowCreation"
+        size="small"
+        flat="true"
+        (click)="createNewPart()"
+    >
+        <icon left>add</icon>
+        {{ 'shared.create_new_construct_part' | i18n }}
+    </gtx-button>
+</div>
 
 <div class="gtx-construct-part-list">
     <table

--- a/cms-ui/apps/admin-ui/src/app/features/construct/components/construct-part-list/construct-part-list.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/construct/components/construct-part-list/construct-part-list.component.ts
@@ -104,11 +104,19 @@ export class ConstructPartListComponent implements OnInit, OnDestroy, ControlVal
     ) { }
 
     ngOnInit(): void {
-        this.form = new UntypedFormArray([], (ctl) => {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-            if ((ctl.value || []).find(value => value === CONTROL_INVALID_VALUE)) {
-                return { invalid: true };
-            }
+        this.form = new UntypedFormArray([], () => {
+            const err = {};
+            let hasErr = false;
+            const toCheck = this.form?.controls ?? [];
+
+            toCheck.forEach((ctl, idx) => {
+                if (ctl.errors != null) {
+                    err[idx] = ctl.errors;
+                    hasErr = true;
+                }
+            });
+
+            return hasErr ? err : null;
         });
 
         if (this.disabled) {

--- a/cms-ui/apps/admin-ui/src/app/features/construct/components/construct-part-properties/construct-part-properties.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/construct/components/construct-part-properties/construct-part-properties.component.ts
@@ -140,7 +140,7 @@ export class ConstructPartPropertiesComponent
     // tslint:disable-next-line: variable-name
     public readonly TagPartTypePropertyType = TagPartTypePropertyType;
     // tslint:disable-next-line: variable-name
-    public readonly ConstructPartPropertiesComponentMode = ConstructPartPropertiesMode;
+    public readonly ConstructPartPropertiesMode = ConstructPartPropertiesMode;
     // tslint:disable-next-line: variable-name
     public readonly TagPartValidatorConfigs = TagPartValidatorConfigs;
 
@@ -214,6 +214,10 @@ export class ConstructPartPropertiesComponent
 
     protected createForm(): UntypedFormGroup {
         return new UntypedFormGroup({
+            // Noop controls
+            globalId: new UntypedFormControl(this.value?.globalId),
+            id: new UntypedFormControl(this.value?.id),
+
             // text
             keyword: new UntypedFormControl(this.value?.keyword ?? null, [
                 Validators.required,
@@ -361,11 +365,9 @@ export class ConstructPartPropertiesComponent
         const { globalId: _globalId, id: _id, keyword: _keyword, ...output } = formData;
 
         if (this.mode === ConstructPartPropertiesMode.UPDATE) {
-            output.globalId = this.value?.globalId;
-            output.id = this.value?.id;
-            output.keyword = this.value?.keyword;
-            output.name = this.value?.name;
-            output.type = this.value?.type;
+            output.globalId = this.value?.globalId ?? formData.globalId;
+            output.id = this.value?.id ?? formData.id;
+            output.keyword = this.value?.keyword ?? this.form.get('keyword').value;
         } else {
             output.keyword = formData.keyword;
         }
@@ -375,23 +377,7 @@ export class ConstructPartPropertiesComponent
 
     protected onValueChange(): void {
         if (this.form && this.value && (this.value as any) !== CONTROL_INVALID_VALUE) {
-            this.form.setValue({
-                keyword: this.value?.keyword ?? null,
-                nameI18n: this.value?.nameI18n ?? null,
-                partOrder: this.value?.partOrder ?? null,
-                typeId: this.value?.typeId ?? null,
-                editable: this.value?.editable ?? null,
-                mandatory: this.value?.mandatory ?? null,
-                hidden: this.value?.hidden ?? null,
-                liveEditable: this.value?.liveEditable ?? null,
-                hideInEditor: this.value?.hideInEditor ?? null,
-                externalEditorUrl: this.value?.externalEditorUrl ?? null,
-                defaultProperty: this.value?.defaultProperty ?? null,
-                markupLanguageId: this.value?.markupLanguageId ?? null,
-                regex: this.value?.regex ?? null,
-                selectSettings: this.value?.selectSettings ?? null,
-                overviewSettings: this.value?.overviewSettings ?? null,
-            });
+            this.form.patchValue(this.value);
         }
     }
 }


### PR DESCRIPTION
Issue with how the validation is currently handled (Is already reworked for 6.1 release) causes tag-parts to corrupt themself when they become invalid once while editing.