### PR TITLE
If publishing fails with a conflict and the object, which causes the

### DIFF
--- a/cms-core/src/main/java/com/gentics/contentnode/publish/mesh/MeshPublisher.java
+++ b/cms-core/src/main/java/com/gentics/contentnode/publish/mesh/MeshPublisher.java
@@ -3586,7 +3586,7 @@ public class MeshPublisher implements AutoCloseable {
 							Node node = Trx.supply(tx -> tx.getObject(Node.class, task.nodeId, false, false, true));
 							NodeObject languageVariant = Trx.supply(() -> task.getLanguageVariant(conflictingLanguage));
 
-							if (!cr.mustContain(languageVariant)) {
+							if (!Trx.supply(() -> cr.mustContain(languageVariant))) {
 								// remove language variant
 								remove(task.project, node, task.objType, conflictingUuid, conflictingLanguage, false);
 								// repeat task
@@ -3598,10 +3598,10 @@ public class MeshPublisher implements AutoCloseable {
 							Optional<Pair<Integer, NodeObject>> optNodeObject = getNodeObject(task.project, task.nodeId, conflictingUuid, conflictingLanguage);
 							if (optNodeObject.isPresent()) {
 								Node node = Trx.supply(tx -> tx.getObject(Node.class, task.nodeId, false, false, true));
-								
+
 								int objType = optNodeObject.get().getLeft();
 								NodeObject conflictingNodeObject = optNodeObject.get().getRight();
-								if (conflictingNodeObject == null || !cr.mustContain(conflictingNodeObject)) {
+								if (conflictingNodeObject == null || !Trx.supply(() -> cr.mustContain(conflictingNodeObject))) {
 									// remove the object from Mesh
 									remove(task.project, node, objType, conflictingUuid, conflictingLanguage, false);
 									// repeat task

--- a/cms-core/src/main/java/com/gentics/contentnode/publish/mesh/MeshPublisher.java
+++ b/cms-core/src/main/java/com/gentics/contentnode/publish/mesh/MeshPublisher.java
@@ -195,9 +195,11 @@ import com.gentics.mesh.core.rest.tag.TagListUpdateRequest;
 import com.gentics.mesh.core.rest.tag.TagReference;
 import com.gentics.mesh.core.rest.tag.TagResponse;
 import com.gentics.mesh.parameter.GenericParameters;
+import com.gentics.mesh.parameter.NodeParameters;
 import com.gentics.mesh.parameter.VersioningParameters;
 import com.gentics.mesh.parameter.client.DeleteParametersImpl;
 import com.gentics.mesh.parameter.client.GenericParametersImpl;
+import com.gentics.mesh.parameter.client.NodeParametersImpl;
 import com.gentics.mesh.parameter.client.SchemaUpdateParametersImpl;
 import com.gentics.mesh.parameter.client.VersioningParametersImpl;
 import com.gentics.mesh.rest.client.MeshRequest;
@@ -260,6 +262,11 @@ public class MeshPublisher implements AutoCloseable {
 	 * Postfix of the name of the schema for files
 	 */
 	public final static String FILE_SCHEMA = "binary_content";
+
+	/**
+	 * Name of the schema for forms
+	 */
+	public final static String FORM_SCHEMA = "form";
 
 	/**
 	 * Name of the tag family used for the implementation version tags
@@ -1024,7 +1031,7 @@ public class MeshPublisher implements AutoCloseable {
 	 * @param objType object type
 	 * @return normalized
 	 */
-	protected static int normalizeObjType(int objType) {
+	public static int normalizeObjType(int objType) {
 		if (objType == ImageFile.TYPE_IMAGE) {
 			return File.TYPE_FILE;
 		}
@@ -2887,9 +2894,34 @@ public class MeshPublisher implements AutoCloseable {
 	public String getSchemaName(int objectType) {
 		switch (objectType) {
 		case Form.TYPE_FORM:
-			return "form";
+			return FORM_SCHEMA;
 		default:
 			return String.format("%s_%s", schemaPrefix, schemaNames.get(normalizeObjType(objectType)));
+		}
+	}
+
+	/**
+	 * Get the object type for the given schema name
+	 * @param schemaName schema name
+	 * @return optional object type, empty if the schema does not belong to a CMS object
+	 */
+	public Optional<Integer> getObjectType(String schemaName) {
+		if (org.apache.commons.lang3.StringUtils.equals(schemaName, FORM_SCHEMA)) {
+			return Optional.of(Form.TYPE_FORM);
+		}
+		if (!org.apache.commons.lang3.StringUtils.startsWith(schemaName, schemaPrefix + "_")) {
+			return Optional.empty();
+		}
+		String typeName = org.apache.commons.lang3.StringUtils.removeStart(schemaName, schemaPrefix + "_");
+		switch (typeName) {
+		case FOLDER_SCHEMA:
+			return Optional.of(Folder.TYPE_FOLDER);
+		case PAGE_SCHEMA:
+			return Optional.of(Page.TYPE_PAGE);
+		case FILE_SCHEMA:
+			return Optional.of(File.TYPE_FILE);
+		default:
+			return Optional.empty();
 		}
 	}
 
@@ -3365,6 +3397,46 @@ public class MeshPublisher implements AutoCloseable {
 	}
 
 	/**
+	 * Do some reverse engineering to get the CMS object which was published to Mesh with the given UUID and language
+	 * @param project mesh project
+	 * @param nodeId node ID
+	 * @param meshUuid mesh UUID
+	 * @param meshLanguage mesh language
+	 * @return optional pair of object type and NodeObject. The optional is empty, if the object in Mesh could not be found or was not published from
+	 * the CMS. Otherwise the pair will always contain the object type and also the NodeObject, if it could be found in the CMS
+	 * @throws NodeException
+	 */
+	public Optional<Pair<Integer, NodeObject>> getNodeObject(MeshProject project, int nodeId, String meshUuid, String meshLanguage) throws NodeException {
+		GenericParameters genParams = new GenericParametersImpl().setETag(false).setFields("uuid", "fields", "schema");
+		NodeParameters langParam = new NodeParametersImpl().setLanguages(meshLanguage);
+		NodeResponse conflict = client
+				.findNodeByUuid(project.name, meshUuid, project.enforceBranch(nodeId), genParams, langParam).toMaybe()
+				.onErrorComplete().blockingGet();
+		if (conflict != null) {
+			String schemaName = conflict.getSchema().getName();
+			Optional<Integer> optCmsId = Optional.ofNullable(conflict.getFields().getNumberField("cms_id"))
+					.flatMap(f -> Optional.ofNullable(f.getNumber())).map(Number::intValue);
+			Optional<Integer> optType = getObjectType(schemaName);
+			if (optType.isPresent() && optCmsId.isPresent()) {
+				int objType = optType.get();
+				int cmsId = optCmsId.get();
+
+				NodeObject object = null;
+				try (Trx trx = new Trx(); ChannelTrx cTrx = new ChannelTrx(nodeId)) {
+					Transaction t = trx.getTransaction();
+					object = t.getObject(t.getClass(objType), cmsId);
+				}
+
+				return Optional.of(Pair.of(objType, object));
+			} else {
+				return Optional.empty();
+			}
+		} else {
+			return Optional.empty();
+		}
+	}
+
+	/**
 	 * Get the parent object of the given object.
 	 * Do not return the root folder, if the CR publishes into project per node
 	 * @param object object
@@ -3520,6 +3592,22 @@ public class MeshPublisher implements AutoCloseable {
 								// repeat task
 								task.perform(false);
 								postpone = false;
+							}
+						} else {
+							// check whether the conflicting node should be removed
+							Optional<Pair<Integer, NodeObject>> optNodeObject = getNodeObject(task.project, task.nodeId, conflictingUuid, conflictingLanguage);
+							if (optNodeObject.isPresent()) {
+								Node node = Trx.supply(tx -> tx.getObject(Node.class, task.nodeId, false, false, true));
+								
+								int objType = optNodeObject.get().getLeft();
+								NodeObject conflictingNodeObject = optNodeObject.get().getRight();
+								if (conflictingNodeObject == null || !cr.mustContain(conflictingNodeObject)) {
+									// remove the object from Mesh
+									remove(task.project, node, objType, conflictingUuid, conflictingLanguage, false);
+									// repeat task
+									task.perform(false);
+									postpone = false;
+								}
 							}
 						}
 					}

--- a/cms-core/src/test/java/com/gentics/contentnode/tests/publish/mesh/MeshPublishFindConflictingObjectTest.java
+++ b/cms-core/src/test/java/com/gentics/contentnode/tests/publish/mesh/MeshPublishFindConflictingObjectTest.java
@@ -1,0 +1,206 @@
+package com.gentics.contentnode.tests.publish.mesh;
+
+import static com.gentics.contentnode.tests.utils.ContentNodeMeshCRUtils.createMeshCR;
+import static com.gentics.contentnode.tests.utils.ContentNodeTestDataUtils.create;
+import static com.gentics.contentnode.tests.utils.ContentNodeTestDataUtils.createFolder;
+import static com.gentics.contentnode.tests.utils.ContentNodeTestDataUtils.createNode;
+import static com.gentics.contentnode.tests.utils.ContentNodeTestDataUtils.createTemplate;
+import static com.gentics.contentnode.tests.utils.ContentNodeTestDataUtils.update;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.gentics.api.lib.exception.NodeException;
+import com.gentics.contentnode.db.DBUtils;
+import com.gentics.contentnode.etc.Feature;
+import com.gentics.contentnode.factory.Trx;
+import com.gentics.contentnode.object.ContentLanguage;
+import com.gentics.contentnode.object.ContentRepository;
+import com.gentics.contentnode.object.File;
+import com.gentics.contentnode.object.Folder;
+import com.gentics.contentnode.object.ImageFile;
+import com.gentics.contentnode.object.Node;
+import com.gentics.contentnode.object.NodeObject;
+import com.gentics.contentnode.object.Page;
+import com.gentics.contentnode.object.Template;
+import com.gentics.contentnode.publish.mesh.MeshPublisher;
+import com.gentics.contentnode.tests.category.MeshTest;
+import com.gentics.contentnode.tests.utils.ContentNodeTestDataUtils.PublishTarget;
+import com.gentics.contentnode.testutils.DBTestContext;
+import com.gentics.contentnode.testutils.GCNFeature;
+import com.gentics.contentnode.testutils.mesh.MeshContext;
+import com.gentics.contentnode.testutils.mesh.MeshTestRule;
+import com.gentics.mesh.util.UUIDUtil;
+import com.gentics.testutils.GenericTestUtils;
+
+/**
+ * Test cases for {@link MeshPublisher#getNodeObject(com.gentics.contentnode.publish.mesh.MeshPublisher.MeshProject, int, String, String)}
+ */
+@GCNFeature(set = { Feature.MESH_CONTENTREPOSITORY })
+@RunWith(value = Parameterized.class)
+@Category(MeshTest.class)
+public class MeshPublishFindConflictingObjectTest {
+	/**
+	 * Name of the mesh project
+	 */
+	public final static String MESH_PROJECT_NAME = "testproject";
+
+	@ClassRule
+	public static DBTestContext context = new DBTestContext();
+
+	@ClassRule
+	public static MeshContext mesh = new MeshContext();
+
+	private static Node node;
+
+	private static Folder folder;
+
+	private static Integer crId;
+
+	private static Template template;
+
+	private static ContentLanguage de;
+
+	@Rule
+	public MeshTestRule meshTestRule = new MeshTestRule(mesh);
+
+	@Parameters(name = "{index}: type {0}")
+	public static Collection<Object[]> data() {
+		Collection<Object[]> data = new ArrayList<>();
+		for (int objType : Arrays.asList(Folder.TYPE_FOLDER, Page.TYPE_PAGE, File.TYPE_FILE, ImageFile.TYPE_IMAGE)) {
+			data.add(new Object[] { objType });
+		}
+		return data;
+	}
+
+	/**
+	 * Setup static test data
+	 * 
+	 * @throws NodeException
+	 */
+	@BeforeClass
+	public static void setupOnce() throws Exception {
+		node = Trx.supply(() -> createNode("node", "Node", PublishTarget.CONTENTREPOSITORY));
+		folder = Trx.supply(() -> createFolder(node.getFolder(), "Folder"));
+		crId = createMeshCR(mesh, MESH_PROJECT_NAME);
+		de = Trx.supply(t -> {
+			Optional<Integer> deId = DBUtils.select("SELECT id FROM contentgroup WHERE code = ?", ps -> {
+				ps.setString(1, "de");
+			}, DBUtils.IDS).stream().findFirst();
+			assertThat(deId).as("ContentLanguage 'de'").isPresent();
+			return t.getObject(ContentLanguage.class, deId.get());
+		});
+
+		Trx.operate(() -> update(node, n -> {
+			n.setContentrepositoryId(crId);
+		}));
+
+		template = Trx.supply(() -> createTemplate(node.getFolder(), "Template"));
+	}
+
+	/**
+	 * Object type
+	 */
+	@Parameter(0)
+	public int objType;
+
+	/**
+	 * Test loading with an inexistent UUID
+	 * @throws Exception
+	 */
+	@Test
+	public void testLoadInexistentObject() throws Exception {
+		// publish
+		try (Trx trx = new Trx()) {
+			context.publish(false);
+			trx.success();
+		}
+
+		ContentRepository cr = Trx.supply(t -> t.getObject(ContentRepository.class, crId));
+		try (Trx trx = new Trx(); MeshPublisher mp = new MeshPublisher(cr)) {
+			mp.checkSchemasAndProjects(false, false);
+			String meshUuid = UUIDUtil.randomUUID();
+			String meshLanguage = "en";
+			Optional<Pair<Integer, NodeObject>> optionalPair = mp.getNodeObject(mp.getProject(node), node.getId(), meshUuid, meshLanguage);
+			assertThat(optionalPair).as("Found object").isEmpty();
+		}
+	}
+
+	/**
+	 * Test loading the object after publishing to Mesh
+	 * @throws Exception
+	 */
+	@Test
+	public void testLoadObject() throws Exception {
+		NodeObject testedObject = null;
+		switch (objType) {
+		case Folder.TYPE_FOLDER:
+			testedObject = Trx.supply(() -> create(Folder.class, f -> {
+				f.setMotherId(folder.getId());
+				f.setName("Testfolder");
+			}));
+			break;
+		case Page.TYPE_PAGE:
+			testedObject = Trx.supply(() -> update(create(Page.class, p -> {
+				p.setFolderId(folder.getId());
+				p.setTemplateId(template.getId());
+				p.setName("Testpage");
+				p.setLanguage(de);
+			}), p -> p.publish()));
+			break;
+		case File.TYPE_FILE:
+			try (InputStream in = new ByteArrayInputStream("Contents".getBytes())) {
+				testedObject = Trx.supply(() -> create(File.class, f -> {
+					f.setFolderId(folder.getId());
+					f.setName("testfile.txt");
+					f.setFileStream(in);
+				}));
+			}
+			break;
+		case ImageFile.TYPE_IMAGE:
+			try (InputStream in = GenericTestUtils.getPictureResource("blume.jpg")) {
+				testedObject = Trx.supply(() -> create(ImageFile.class, f -> {
+					f.setFolderId(folder.getId());
+					f.setName("blume.jpg");
+					f.setFileStream(in);
+				}));
+			}
+			break;
+		}
+
+		// publish
+		try (Trx trx = new Trx()) {
+			context.publish(false);
+			trx.success();
+		}
+
+		ContentRepository cr = Trx.supply(t -> t.getObject(ContentRepository.class, crId));
+		try (Trx trx = new Trx(); MeshPublisher mp = new MeshPublisher(cr)) {
+			mp.checkSchemasAndProjects(false, false);
+			String meshUuid = MeshPublisher.getMeshUuid(testedObject);
+			String meshLanguage = MeshPublisher.getMeshLanguage(testedObject);
+			Optional<Pair<Integer, NodeObject>> optionalPair = mp.getNodeObject(mp.getProject(node), node.getId(), meshUuid, meshLanguage);
+			assertThat(optionalPair).as("Found object").isNotEmpty();
+			assertThat(optionalPair.get()).as("Found object").isNotNull();
+			assertThat(optionalPair.get().getLeft()).as("Object type").isEqualTo(MeshPublisher.normalizeObjType(testedObject.getTType()));
+			assertThat(optionalPair.get().getRight()).as("Object").isEqualTo(testedObject);
+			trx.success();
+		}
+	}
+}

--- a/cms-oss-changelog/src/changelog/entries/2023/10/7585.SUP-15727.bugfix
+++ b/cms-oss-changelog/src/changelog/entries/2023/10/7585.SUP-15727.bugfix
@@ -1,0 +1,1 @@
+The conflict resolving behaviour when publishing into a Mesh Content.Repository has been improved.


### PR DESCRIPTION
conflict should have been removed from Mesh, do it now.