### PR TITLE
SUP-16080: CMS Version 5.45: Übersetzung (in mehrere Sprachen) Template ist nichtvor-ausgewählt

### DIFF
--- a/cms-oss-changelog/src/changelog/entries/2023/12/7630.SUP-16080.bugfix
+++ b/cms-oss-changelog/src/changelog/entries/2023/12/7630.SUP-16080.bugfix
@@ -1,0 +1,1 @@
+Editor User Interface: The preselection of templates while creating language variants of pages has been fixed.

--- a/cms-ui/apps/editor-ui/src/app/shared/components/item-list-row/item-list-row.component.ts
+++ b/cms-ui/apps/editor-ui/src/app/shared/components/item-list-row/item-list-row.component.ts
@@ -49,7 +49,7 @@ type AllowedItemType =
     templateUrl: './item-list-row.component.html',
     styleUrls: ['./item-list-row.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
-    })
+})
 export class ItemListRowComponent implements OnInit {
 
     readonly UIMode = UIMode;
@@ -250,7 +250,7 @@ export class ItemListRowComponent implements OnInit {
                     description: item.description || '',
                     language: language.code,
                     priority: item.priority,
-                    templateId: item.template ,
+                    templateId: item.templateId,
                 },
                 languageName: language.name,
                 pageId: item.id,


### PR DESCRIPTION
Issue: https://jira.gentics.com/browse/SUP-16080