### PR TITLE
GPU-1384: Mesh Browser - UI Language Support, Editor Fields, Improvements, Translations, Fixes

### DIFF
--- a/cms-ui/apps/admin-ui/src/app/app-routing.module.ts
+++ b/cms-ui/apps/admin-ui/src/app/app-routing.module.ts
@@ -507,7 +507,7 @@ const ADMIN_UI_ROUTES: GcmsAdminUiRoute[] = [
 @NgModule({
     imports: [
         RouterModule.forRoot(ADMIN_UI_ROUTES, {
-            enableTracing: false,
+            enableTracing: true,
             bindToComponentInputs: true,
         }),
     ],

--- a/cms-ui/apps/admin-ui/src/app/app-routing.module.ts
+++ b/cms-ui/apps/admin-ui/src/app/app-routing.module.ts
@@ -507,7 +507,7 @@ const ADMIN_UI_ROUTES: GcmsAdminUiRoute[] = [
 @NgModule({
     imports: [
         RouterModule.forRoot(ADMIN_UI_ROUTES, {
-            enableTracing: true,
+            enableTracing: false,
             bindToComponentInputs: true,
         }),
     ],

--- a/cms-ui/apps/admin-ui/src/app/core/providers/i18n/translations/mesh.translations.json
+++ b/cms-ui/apps/admin-ui/src/app/core/providers/i18n/translations/mesh.translations.json
@@ -782,6 +782,10 @@
         "en": "No Project available",
         "de": "Keine Projekte verfügbar"
     },
+    "browser_no_schema_elements": {
+        "en": "This node has no schema elements",
+        "de": "Dieser Node hat keine Schema-Elemente"
+    },
 
     "published_state_published": {
         "en": "Published",

--- a/cms-ui/apps/admin-ui/src/app/core/providers/i18n/translations/mesh.translations.json
+++ b/cms-ui/apps/admin-ui/src/app/core/providers/i18n/translations/mesh.translations.json
@@ -781,5 +781,26 @@
     "browser_no_projects": {
         "en": "No Project available",
         "de": "Keine Projekte verfügbar"
+    },
+
+    "published_state_published": {
+        "en": "Published",
+        "de": "Publiziert"
+    },
+    "published_state_archived": {
+        "en": "Archived",
+        "de": "Archiviert"
+    },
+    "published_state_draft": {
+        "en": "Draft",
+        "de": "Entwurf"
+    },
+    "published_state_updated": {
+        "en": "Updated",
+        "de": "Geändert"
+    },
+    "published_state_changed": {
+        "en": "Last modified at",
+        "de": "Geändert am"
     }
 }

--- a/cms-ui/apps/admin-ui/src/app/core/providers/logout-cleanup/logout-cleanup.service.ts
+++ b/cms-ui/apps/admin-ui/src/app/core/providers/logout-cleanup/logout-cleanup.service.ts
@@ -32,6 +32,7 @@ export class LogoutCleanupService extends InitializableServiceBase {
         messages: () => this.appState.dispatch(new ClearMessageState()),
         permissions: () => this.appState.dispatch(new ClearAllPermissions()),
         ui: null,
+        mesh: null,
     };
 
     constructor(

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-content-version/mesh-browser-content-version.component.html
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-content-version/mesh-browser-content-version.component.html
@@ -8,5 +8,5 @@
             <icon *ngSwitchCase="PublishedState.UPDATED" class="updated">cloud_upload</icon>
         </container-element>
     </div>
-    <span class="state-text">{{ publishedState }}</span>
+    <span class="state-text">{{ PublishedStateTranslations.get(publishedState) | i18n  }}</span>
 </div>

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-content-version/mesh-browser-content-version.component.scss
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-content-version/mesh-browser-content-version.component.scss
@@ -53,5 +53,6 @@
 
     .state-text {
         margin-top: 0.12rem;
+        text-transform: uppercase;
     }
 }

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-content-version/mesh-browser-content-version.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-content-version/mesh-browser-content-version.component.ts
@@ -1,5 +1,6 @@
 
 import { Component, Input, OnInit } from '@angular/core';
+import { I18nService } from '@admin-ui/core';
 import { PublishedState, SchemaElement } from '../../models/mesh-browser-models';
 
 @Component({
@@ -16,19 +17,27 @@ export class MeshBrowserContentVersionComponent implements OnInit {
 
     public publishedState: PublishedState;
 
+    public readonly PublishedStateTranslations = new Map<string, string>([
+        [PublishedState.PUBLISHED, 'mesh.published_state_published'],
+        [PublishedState.ARCHIVED, 'mesh.published_state_archived'],
+        [PublishedState.DRAFT, 'mesh.published_state_draft'],
+        [PublishedState.UPDATED, 'mesh.published_state_updated'],
+    ]);
+
     public title = '';
 
-    constructor() { }
+    constructor(protected i18n: I18nService) { }
+
 
     ngOnInit(): void {
         this.publishedState = this.getPublishedState();
 
-        this.title = `version: ${this.schemaElement?.version}`;
+        this.title = `Version: ${this.schemaElement?.version}\n`;
 
         if (this.schemaElement?.versions?.length > 0) {
             const created = this.schemaElement.versions[0].created;
             const createdDate = new Date(created).toLocaleString()
-            this.title += ` last modified at: ${createdDate}`;
+            this.title += `${this.i18n.instant('mesh.published_state_changed')}: ${createdDate}`;
         }
     }
 

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-content-version/mesh-browser-content-version.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-content-version/mesh-browser-content-version.component.ts
@@ -31,7 +31,6 @@ export class MeshBrowserContentVersionComponent implements OnInit {
 
     ngOnInit(): void {
         this.publishedState = this.getPublishedState();
-
         this.title = `Version: ${this.schemaElement?.version}\n`;
 
         if (this.schemaElement?.versions?.length > 0) {

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-content-version/mesh-browser-content-version.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-content-version/mesh-browser-content-version.component.ts
@@ -1,6 +1,6 @@
 
 import { Component, Input, OnInit } from '@angular/core';
-import { PublishedState, SchemaElement, SchemaElementVersion } from '../../models/mesh-browser-models';
+import { PublishedState, SchemaElement } from '../../models/mesh-browser-models';
 
 @Component({
     selector: 'gtx-mesh-browser-content-version',
@@ -46,8 +46,8 @@ export class MeshBrowserContentVersionComponent implements OnInit {
                 if (this.hasPublishedVersion()) {
                     return PublishedState.UPDATED;
                 }
-                if (this.schemaElement.isDraft) {
-                    // no published version and draft => ARCHIVED
+                if (RegExp('.0$').exec(version.version)) {
+                    // no published but major version => ARCHIVED
                     return PublishedState.ARCHIVED
                 }
 

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-editor/mesh-browser-editor.component.html
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-editor/mesh-browser-editor.component.html
@@ -15,17 +15,17 @@
             {{ title   }}
             <span class="language-indicator">{{ currentLanguage.toLocaleUpperCase() }}</span>
         </h2>
-
     </gtx-entity-detail-header>
+
+    
+    <gtx-mesh-copy-value [value]="currentNodeUuid" [label]="'UUID'" class="copy-uuid" />
+
 
     <ng-container *ngFor="let field of fields">
         <div class="field">
             <label class="field-label">{{ field.label }}</label>
 
             <div [ngSwitch]="field.type" class="field-value-wrapper">
-                <span *ngSwitchCase="'string'" class="field-value">
-                    {{ field.value }}
-                </span>
 
                 <ng-container *ngSwitchCase="'list'">
                     <div *ngFor="let field of field.value" class="field-value">
@@ -45,7 +45,9 @@
                     </ng-template>
                 </ng-container>    
 
-
+                <span *ngSwitchDefault class="field-value">
+                    {{ field.value }}
+                </span>
             </div>
         </div>
 

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-editor/mesh-browser-editor.component.html
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-editor/mesh-browser-editor.component.html
@@ -36,6 +36,16 @@
                 <div *ngSwitchCase="'binary'" class="field-binary">
                     <img src="{{ field.value }}" />
                 </div>    
+
+                <ng-container *ngSwitchCase="'boolean'" >
+                    <icon *ngIf="field.value === true; else booleanRenderer" left class="boolean-true">check</icon>
+                
+                    <ng-template #booleanRenderer>
+                        <icon left class="boolean-false">close</icon>
+                    </ng-template>
+                </ng-container>    
+
+
             </div>
         </div>
 

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-editor/mesh-browser-editor.component.html
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-editor/mesh-browser-editor.component.html
@@ -27,11 +27,11 @@
 
             <div [ngSwitch]="field.type" class="field-value-wrapper">
 
-                <ng-container *ngSwitchCase="'list'">
+                <div class="list" *ngSwitchCase="'list'">
                     <div *ngFor="let field of field.value" class="field-value">
                         {{ field }}
                     </div>
-                </ng-container>
+                </div>
                 
                 <div *ngSwitchCase="'binary'" class="field-binary">
                     <img src="{{ field.value }}" />

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-editor/mesh-browser-editor.component.html
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-editor/mesh-browser-editor.component.html
@@ -18,7 +18,7 @@
     </gtx-entity-detail-header>
 
     
-    <gtx-mesh-copy-value [value]="currentNodeUuid" [label]="'UUID'" class="copy-uuid" />
+    <gtx-mesh-copy-value [value]="currentNodeUuid" [label]="'UUID'" [animate]="true" class="copy-uuid" />
 
 
     <ng-container *ngFor="let field of fields">

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-editor/mesh-browser-editor.component.html
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-editor/mesh-browser-editor.component.html
@@ -22,18 +22,18 @@
         <div class="field">
             <label class="field-label">{{ field.label }}</label>
 
-            <div class="field-value-wrapper">
-                <span *ngIf="field.type === 'string'" class="field-value">
+            <div [ngSwitch]="field.type" class="field-value-wrapper">
+                <span *ngSwitchCase="'string'" class="field-value">
                     {{ field.value }}
                 </span>
 
-                <ng-container *ngIf="field.type === 'list'">
+                <ng-container *ngSwitchCase="'list'">
                     <div *ngFor="let field of field.value" class="field-value">
                         {{ field }}
                     </div>
                 </ng-container>
                 
-                <div *ngIf="field.type === 'binary'" class="field-binary">
+                <div *ngSwitchCase="'binary'" class="field-binary">
                     <img src="{{ field.value }}" />
                 </div>    
             </div>

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-editor/mesh-browser-editor.component.scss
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-editor/mesh-browser-editor.component.scss
@@ -62,6 +62,12 @@
     .boolean-true {
         color: #449d44;
     }
+
+    .list {
+        padding: 0.5rem;
+        border: 2px solid lightgrey;
+        border-radius: 4px;
+    }
 }
 
 

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-editor/mesh-browser-editor.component.scss
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-editor/mesh-browser-editor.component.scss
@@ -64,6 +64,28 @@
     }
 }
 
+
+.copy-uuid {
+    color: $gtx-color-primary;
+    font-size: 12px;
+    height: 60px;
+    display: flex;
+    padding: 0;
+
+    ::ng-deep .copy-button {
+        padding: 0.5rem 1rem !important;
+        font-size: 1rem !important;
+        width: 1.25rem !important;
+    }
+
+    ::ng-deep .label {
+        margin-left: 0.5rem;
+        margin-top: 0.5rem;
+        font-size: 18px;
+        margin-right: 1rem;
+    }
+}
+
 .language-indicator {
     font-size: 19px;
     margin-right: 5px;

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-editor/mesh-browser-editor.component.scss
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-editor/mesh-browser-editor.component.scss
@@ -55,8 +55,14 @@
             max-height: 100%;
         }
     }
-}
 
+    .boolean-false {
+        color: #c9302c;
+    }
+    .boolean-true {
+        color: #449d44;
+    }
+}
 
 .language-indicator {
     font-size: 19px;

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-editor/mesh-browser-editor.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-editor/mesh-browser-editor.component.ts
@@ -27,8 +27,6 @@ export class MeshBrowserEditorComponent  implements OnInit, OnChanges {
     @Input({ alias: ROUTE_MESH_LANGUAGE})
     public currentLanguage: string;
 
-    private currentNodeSchemaName: string;
-
     public fields: Array<MeshField> = [];
 
     public title: string;
@@ -53,7 +51,6 @@ export class MeshBrowserEditorComponent  implements OnInit, OnChanges {
     }
 
     async updateComponent(): Promise<void> {
-        this.currentNodeSchemaName = await this.loader.getSchemaNameForNode(this.project, {nodeUuid: this.currentNodeUuid})
         await this.mapResponseToSchemaFields()
         this.changeDetector.markForCheck();
     }
@@ -88,7 +85,6 @@ export class MeshBrowserEditorComponent  implements OnInit, OnChanges {
             }
 
             if (fieldDefinition.type === FieldType.NODE) {
-                console.log(fieldDefinition);
                 const node = response.fields[fieldDefinition.name] as unknown as object;
                 fieldValue = node['displayName'] ?? node['uuid'];
             }
@@ -102,10 +98,12 @@ export class MeshBrowserEditorComponent  implements OnInit, OnChanges {
     }
 
     private async getCurrentSchema(): Promise<SchemaContainer> {
-        let currentSchema = this.appState.now.mesh.schemas.find(schema => schema.name === this.currentNodeSchemaName)
-        if( !currentSchema ){
+        const currentNodeSchemaName = await this.loader.getSchemaNameForNode(this.project, this.currentNodeUuid)
+
+        let currentSchema = this.appState.now.mesh.schemas.find(schema => schema.name === currentNodeSchemaName)
+        if (!currentSchema) {
             const schemas =  await this.loader.listProjectSchemas(this.project);
-            currentSchema = schemas.find(schema => schema.name === this.currentNodeSchemaName)
+            currentSchema = schemas.find(schema => schema.name === currentNodeSchemaName)
             this.appState.dispatch(new SchemasLoaded(schemas));
         }
 

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-editor/mesh-browser-editor.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-editor/mesh-browser-editor.component.ts
@@ -82,30 +82,38 @@ export class MeshBrowserEditorComponent  implements OnInit, OnChanges {
         this.fields = [];
 
         for (const [key, value] of Object.entries(response.fields)) {
-            // type should be from api response
             const fieldType = this.getFieldType(value);
 
-            if (fieldType === FieldType.STRING || fieldType === FieldType.LIST) {
-                this.fields.push({
-                    label: key,
-                    value: value as unknown as string,
-                    type: fieldType,
-                })
-            }
-            else if (fieldType === FieldType.NODE) {
-                const fieldObject = value as unknown as object;
-                this.fields.push({
-                    label: key,
-                    value: fieldObject['uuid'],
-                    type: FieldType.STRING,
-                })
-            }
-            else if (fieldType === FieldType.BINARY) {
-                this.fields.push({
-                    label: key,
-                    value: this.getImagePath(key),
-                    type: FieldType.BINARY,
-                })
+            switch(fieldType) {
+                case FieldType.STRING || FieldType.LIST:
+                    this.fields.push({
+                        label: key,
+                        value: value as unknown as string,
+                        type: fieldType,
+                    })
+                    break;
+                case FieldType.NODE:
+                    const fieldObject = value as unknown as object;
+                    this.fields.push({
+                        label: key,
+                        value: fieldObject['displayName'] ?? fieldObject['uuid'],
+                        type: FieldType.STRING,
+                    })
+                    break;
+                case FieldType.BINARY:
+                    this.fields.push({
+                        label: key,
+                        value: this.getImagePath(key),
+                        type: FieldType.BINARY,
+                    })
+                    break;
+                case FieldType.BOOLEAN:
+                    this.fields.push({
+                        label: key,
+                        value: value as unknown as string,
+                        type: FieldType.BOOLEAN,
+                    })
+                    break;
             }
         }
     }
@@ -121,6 +129,8 @@ export class MeshBrowserEditorComponent  implements OnInit, OnChanges {
     }
 
     private getFieldType(field: SchemaField): FieldType {
+        console.log("t", field, );
+
         if (typeof field === 'object') {
             if (field.constructor === Array) {
                 return FieldType.LIST
@@ -134,9 +144,16 @@ export class MeshBrowserEditorComponent  implements OnInit, OnChanges {
                 return FieldType.NODE;
             }
         }
-        else if (typeof field === 'string') {
+        else if (typeof field === 'boolean') {
+            return FieldType.BOOLEAN;
+        }
+        else if (typeof field === 'number') {
             return FieldType.STRING;
         }
+
+        console.warn('type not resolveable', typeof field);
+
+        return FieldType.STRING;
     }
 
     async detailsClose(): Promise<void> {

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-language-switcher/mesh-browser-language-switcher.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-language-switcher/mesh-browser-language-switcher.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, Output } from '@angular/core';
+import { I18nService } from '@admin-ui/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { MeshBrowserLoaderService } from '../../providers';
 
 
@@ -21,11 +22,12 @@ export class MeshBrowserLanguageSwitcherComponent {
 
 
     constructor(
-        protected changeDetector: ChangeDetectorRef,
         protected loader: MeshBrowserLoaderService,
+        protected i18n: I18nService,
     ) { }
 
     public languageChangeHandler(language: string): void {
+        this.i18n.setLanguage(language);
         this.languageChange.emit(language);
     }
 

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-master/mesh-browser-master.component.html
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-master/mesh-browser-master.component.html
@@ -57,6 +57,6 @@
 
 <ng-template #noProjectRenderer>
     <div class="no-project">
-        <h4>{{ 'browser_no_projects' | i18n }}</h4>
+        <h4>{{ 'mesh.browser_no_projects' | i18n }}</h4>
     </div>
 </ng-template>

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-master/mesh-browser-master.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-master/mesh-browser-master.component.ts
@@ -18,7 +18,6 @@ import {
     Component,
     Input,
     OnChanges,
-    SimpleChanges,
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ContentRepository } from '@gentics/cms-models';
@@ -148,13 +147,14 @@ export class MeshBrowserMasterComponent
 
     protected async loadProjectDetails(): Promise<void> {
         if (this.loggedIn) {
-            const languages = await this.loader.getAllLanguages();
+            const [languages, defaultLanguage, projects] = await Promise.all([
+                this.loader.getAllLanguages(),
+                this.loader.getDefaultLanguage(),
+                this.loader.getProjects(),
+            ]);
+
             this.languages = languages.map(language => language.languageTag).sort((a, b) => a.localeCompare(b));
-
-            const defaultLanguage = await this.loader.getDefaultLanguage();
             this.currentLanguage = defaultLanguage.languageTag;
-
-            const projects = await this.loader.getProjects();
 
             if (projects.length > 0) {
                 this.projects = projects.map(project => project.name);

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-master/mesh-browser-master.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-master/mesh-browser-master.component.ts
@@ -1,6 +1,7 @@
 import {
     ContentRepositoryBO,
     EditableEntity,
+    FALLBACK_LANGUAGE,
     ROUTE_DATA_MESH_REPO_ITEM,
     ROUTE_MESH_BRANCH_ID,
     ROUTE_MESH_LANGUAGE,
@@ -23,7 +24,6 @@ import { ContentRepository } from '@gentics/cms-models';
 import { BranchReference, ProjectResponse, User } from '@gentics/mesh-models';
 import { MeshBrowserLoaderService, MeshBrowserNavigatorService } from '../../providers';
 
-const DEFAULT_LANGUAGE = 'de';  // todo: take from api: GPU-1249
 
 @Component({
     selector: 'gtx-mesh-browser-master',
@@ -61,7 +61,7 @@ export class MeshBrowserMasterComponent
     public languages: Array<string> = [];
 
     @Input({ alias: ROUTE_MESH_LANGUAGE })
-    public currentLanguage = DEFAULT_LANGUAGE;
+    public currentLanguage = FALLBACK_LANGUAGE;
 
 
     constructor(
@@ -81,10 +81,6 @@ export class MeshBrowserMasterComponent
         const loadedRepository = this.route.snapshot.data[ROUTE_DATA_MESH_REPO_ITEM];
         if (loadedRepository != null) {
             this.selectedRepository = loadedRepository;
-        }
-
-        if (!this.currentLanguage) {
-            this.currentLanguage = DEFAULT_LANGUAGE;
         }
 
         if (this.parentNodeUuid && this.loggedIn) {
@@ -152,7 +148,7 @@ export class MeshBrowserMasterComponent
     protected async loadProjectDetails(): Promise<void> {
         if (this.loggedIn) {
             const languages = await this.loader.getAllLanguages();
-            this.languages = languages.map(language => language.languageTag);
+            this.languages = languages.map(language => language.languageTag).sort((a, b) => a.localeCompare(b));
 
             const defaultLanguage = await this.loader.getDefaultLanguage();
             this.currentLanguage = defaultLanguage.languageTag;

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-master/mesh-browser-master.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-master/mesh-browser-master.component.ts
@@ -17,8 +17,6 @@ import {
     Component,
     Input,
     OnChanges,
-    OnInit,
-    SimpleChanges,
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ContentRepository } from '@gentics/cms-models';
@@ -60,10 +58,10 @@ export class MeshBrowserMasterComponent
     @Input({ alias: ROUTE_MESH_PARENT_NODE_ID })
     public parentNodeUuid: string;
 
-    public languages: Array<string> = ['de', 'en']; // todo: take from api: GPU-1249
+    public languages: Array<string> = [];
 
     @Input({ alias: ROUTE_MESH_LANGUAGE })
-    public currentLanguage = DEFAULT_LANGUAGE; // todo: take from api: GPU-1249
+    public currentLanguage = DEFAULT_LANGUAGE;
 
 
     constructor(
@@ -153,10 +151,13 @@ export class MeshBrowserMasterComponent
 
     protected async loadProjectDetails(): Promise<void> {
         if (this.loggedIn) {
-            const projects = await this.loader.getProjects();
-
             const languages = await this.loader.getAllLanguages();
             this.languages = languages.map(language => language.languageTag);
+
+            const defaultLanguage = await this.loader.getDefaultLanguage();
+            this.currentLanguage = defaultLanguage.languageTag;
+
+            const projects = await this.loader.getProjects();
 
             if (projects.length > 0) {
                 this.projects = projects.map(project => project.name);

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-master/mesh-browser-master.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-master/mesh-browser-master.component.ts
@@ -34,7 +34,7 @@ const DEFAULT_LANGUAGE = 'de';  // todo: take from api: GPU-1249
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MeshBrowserMasterComponent
-    extends BaseTableMasterComponent<ContentRepository, ContentRepositoryBO> implements OnInit, OnChanges {
+    extends BaseTableMasterComponent<ContentRepository, ContentRepositoryBO> implements OnChanges {
     protected entityIdentifier = EditableEntity.CONTENT_REPOSITORY;
 
     public selectedRepository: ContentRepository;
@@ -78,10 +78,8 @@ export class MeshBrowserMasterComponent
         super(changeDetector, router, route, appState);
     }
 
-    ngOnInit(): void { }
 
-
-    ngOnChanges(changes: SimpleChanges): void {
+    ngOnChanges(): void {
         const loadedRepository = this.route.snapshot.data[ROUTE_DATA_MESH_REPO_ITEM];
         if (loadedRepository != null) {
             this.selectedRepository = loadedRepository;
@@ -156,6 +154,9 @@ export class MeshBrowserMasterComponent
     protected async loadProjectDetails(): Promise<void> {
         if (this.loggedIn) {
             const projects = await this.loader.getProjects();
+
+            const languages = await this.loader.getAllLanguages();
+            this.languages = languages.map(language => language.languageTag);
 
             if (projects.length > 0) {
                 this.projects = projects.map(project => project.name);

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-master/mesh-browser-master.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-master/mesh-browser-master.component.ts
@@ -18,6 +18,7 @@ import {
     Component,
     Input,
     OnChanges,
+    SimpleChanges,
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ContentRepository } from '@gentics/cms-models';
@@ -82,6 +83,9 @@ export class MeshBrowserMasterComponent
         if (loadedRepository != null) {
             this.selectedRepository = loadedRepository;
         }
+
+        console.log("changes");
+        
 
         if (this.parentNodeUuid && this.loggedIn) {
             this.navigatorService.handleBreadcrumbNavigation(
@@ -194,6 +198,10 @@ export class MeshBrowserMasterComponent
     public async projectChangeHandler(project: string): Promise<void> {
         this.currentProject = project;
         this.branches = await this.loader.getBranches(this.currentProject);
+        this.parentNodeUuid = await this.loader.getProjectRootNodeUuid(this.currentProject);
+        this.setCurrentBranch(this.branches);
+
+        this.changeDetector.markForCheck();
         this.handleNavigation();
     }
 

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-master/mesh-browser-master.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-master/mesh-browser-master.component.ts
@@ -84,9 +84,6 @@ export class MeshBrowserMasterComponent
             this.selectedRepository = loadedRepository;
         }
 
-        console.log("changes");
-        
-
         if (this.parentNodeUuid && this.loggedIn) {
             this.navigatorService.handleBreadcrumbNavigation(
                 this.selectedRepository?.id,

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-master/mesh-browser-master.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-master/mesh-browser-master.component.ts
@@ -212,17 +212,7 @@ export class MeshBrowserMasterComponent
         if (this.parentNodeUuid !== nodeId) {
             this.parentNodeUuid = nodeId;
             this.handleBreadcrumbNavigation(nodeId);
-
-            const routeCommand = this.navigatorService.getRouteCommand(
-                this.selectedRepository.id,
-                this.currentProject,
-                this.currentBranchUuid,
-                this.parentNodeUuid,
-                this.currentLanguage,
-            );
-            // merely update path without performing a reload
-            const url = this.router.createUrlTree(routeCommand, {relativeTo: this.route}).toString()
-            this.location.go(url);
+            this.handleNavigation();
         }
     }
 

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-schema-items/mesh-browser-schema-items.component.scss
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-schema-items/mesh-browser-schema-items.component.scss
@@ -35,7 +35,7 @@
 
     .schema-element {
         color: $gtx-color-primary;
-        padding: 0.3rem 0;
+        padding: 0.4rem 0;
         padding-left: 0.4rem;
         margin: 0rem 0;
         cursor: pointer;

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-schema-items/mesh-browser-schema-items.component.scss
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-schema-items/mesh-browser-schema-items.component.scss
@@ -54,6 +54,7 @@
             background: $gtx-color-light-gray;
             color: black;
             font-weight: 500;
+            cursor: default;
 
             &.active {
                 border-bottom: 1px solid $gtx-color-off-black;

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-schema-items/mesh-browser-schema-items.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-schema-items/mesh-browser-schema-items.component.ts
@@ -45,6 +45,9 @@ export class MeshBrowserSchemaItemsComponent implements OnChanges {
     @Output()
     public nodeChanged = new EventEmitter<string>();
 
+    @Output()
+    public elementsLoaded = new EventEmitter<number>();
+
     public page = 1;
 
     public perPage = 10;
@@ -120,6 +123,7 @@ export class MeshBrowserSchemaItemsComponent implements OnChanges {
         this.schemaElements = schemaElements?.sort((a,b) => a.displayName?.localeCompare(b.displayName));
         this.changeDetector.markForCheck();
         this.nodeChanged.emit(nodeUuid)
+        this.elementsLoaded.emit(this.schemaElements?.length ?? 0);
     }
 
     public changePage(page: number): void {

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-schema-items/mesh-browser-schema-items.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-schema-items/mesh-browser-schema-items.component.ts
@@ -114,6 +114,7 @@ export class MeshBrowserSchemaItemsComponent implements OnChanges {
             nodeUuid: nodeUuid,
             lang: this.languages,
             page: this.page,
+            perPage: this.perPage,
         }, this.currentBranch?.uuid);
 
         schemaElements?.forEach((schemaElement) =>
@@ -134,6 +135,7 @@ export class MeshBrowserSchemaItemsComponent implements OnChanges {
             nodeUuid: this.currentNodeUuid,
             page: this.page,
             lang: this.languages,
+            perPage: this.perPage,
         }, this.currentBranch.uuid)
     }
 

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-schema-items/mesh-browser-schema-items.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-schema-items/mesh-browser-schema-items.component.ts
@@ -64,11 +64,11 @@ export class MeshBrowserSchemaItemsComponent implements OnChanges {
     ) { }
 
     ngOnChanges(changes: SimpleChanges): void {
-        if (changes?.currentNodeUuid || changes?.currentProject  || changes?.currentBranch || changes?.currentLanguage) {
+        if (changes?.currentNodeUuid || changes?.currentProject || changes?.currentBranch || changes?.currentLanguage) {
             this.page = 1;
             // make sure current language is the first element
-            this.languages = this.languages.sort((a,_b) => a === this.currentLanguage ? -1 : 1)
-            this.loadNodeContent(this.currentNodeUuid)
+            this.languages = this.languages.sort((a,_b) => a === this.currentLanguage ? -1 : 1);
+            this.loadNodeContent(this.currentNodeUuid);
         }
     }
 

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-schema-list/mesh-browser-schema-list.component.html
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-schema-list/mesh-browser-schema-list.component.html
@@ -8,6 +8,12 @@
                 [languages]="languages"
                 [currentLanguage]="currentLanguage"
                 (nodeChanged)="nodeChanged($event)"
+                (elementsLoaded)="elementsLoaded($event)"
             />
     </ng-container>
+
+    <div *ngIf="noSchemaElements" class="no-schema-elements">
+        {{ 'mesh.browser_no_schema_elements' | i18n}}
+    </div>
+
 </div>

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-schema-list/mesh-browser-schema-list.component.scss
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-schema-list/mesh-browser-schema-list.component.scss
@@ -4,3 +4,8 @@
     overflow-y: auto;
     max-height: 75vh;
 }    
+
+.no-schema-elements {
+    margin: 1rem 0;
+    font-weight: 300;
+}

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-schema-list/mesh-browser-schema-list.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-schema-list/mesh-browser-schema-list.component.ts
@@ -60,7 +60,7 @@ export class MeshBrowserSchemaListComponent implements OnInit, OnChanges {
     protected async loadSchemas(): Promise<void> {
         this.noSchemaElements = true;
         this.schemas = await this.loader.listProjectSchemas(this.currentProject)
-        this.schemas = this.schemas.sort((a,b) => a.name === b.name ? -1 :1)
+        this.schemas = this.schemas.sort((a,b) => (a.name > b.name) ? 1 : ((b.name > a.name) ? -1 : 0))
         this.appState.dispatch(new SchemasLoaded(this.schemas));
 
         if (!this.currentNodeUuid) {

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-schema-list/mesh-browser-schema-list.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-schema-list/mesh-browser-schema-list.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { BranchReference } from '@gentics/mesh-models';
 import { SchemaContainer } from '../../models/mesh-browser-models';
@@ -11,7 +11,7 @@ import { MeshBrowserLoaderService } from '../../providers';
     styleUrls: ['./mesh-browser-schema-list.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MeshBrowserSchemaListComponent implements OnInit {
+export class MeshBrowserSchemaListComponent implements OnInit, OnChanges {
 
     @Input()
     public currentProject: string;
@@ -33,13 +33,20 @@ export class MeshBrowserSchemaListComponent implements OnInit {
 
     public schemas: Array<SchemaContainer> = [];
 
+    public noSchemaElements = true;
+
+
     constructor(
         protected changeDetector: ChangeDetectorRef,
         protected loader: MeshBrowserLoaderService,
         protected route: ActivatedRoute,
     ) { }
 
-    ngOnInit(): void{
+    ngOnChanges(): void {
+        this.noSchemaElements = true;
+    }
+
+    ngOnInit(): void {
         this.route.params.subscribe((params) => {
             if (params.parent) {
                 this.currentNodeUuid = params.parent
@@ -49,6 +56,7 @@ export class MeshBrowserSchemaListComponent implements OnInit {
     }
 
     protected async loadSchemas(): Promise<void> {
+        this.noSchemaElements = true;
         this.schemas = await this.loader.listProjectSchemas(this.currentProject)
         this.schemas = this.schemas.sort((a,b) => a.name === b.name ? -1 :1)
 
@@ -68,6 +76,12 @@ export class MeshBrowserSchemaListComponent implements OnInit {
         }
         this.currentNodeUuid = nodeUuid;
         this.nodeChange.emit(nodeUuid);
+    }
+
+    public elementsLoaded(numberOfElements: number): void {
+        if (numberOfElements > 0) {
+            this.noSchemaElements = false;
+        }
     }
 
 }

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-schema-list/mesh-browser-schema-list.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/components/mesh-browser-schema-list/mesh-browser-schema-list.component.ts
@@ -1,3 +1,4 @@
+import { AppStateService, SchemasLoaded } from '@admin-ui/state';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { BranchReference } from '@gentics/mesh-models';
@@ -40,6 +41,7 @@ export class MeshBrowserSchemaListComponent implements OnInit, OnChanges {
         protected changeDetector: ChangeDetectorRef,
         protected loader: MeshBrowserLoaderService,
         protected route: ActivatedRoute,
+        protected appState: AppStateService,
     ) { }
 
     ngOnChanges(): void {
@@ -59,6 +61,7 @@ export class MeshBrowserSchemaListComponent implements OnInit, OnChanges {
         this.noSchemaElements = true;
         this.schemas = await this.loader.listProjectSchemas(this.currentProject)
         this.schemas = this.schemas.sort((a,b) => a.name === b.name ? -1 :1)
+        this.appState.dispatch(new SchemasLoaded(this.schemas));
 
         if (!this.currentNodeUuid) {
             this.currentNodeUuid = await this.loader.getRootNodeUuid(this.currentProject);

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/models/mesh-browser-models.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/models/mesh-browser-models.ts
@@ -1,4 +1,4 @@
-import { FieldType, PagingOptions } from '@gentics/mesh-models';
+import { FieldType, PagingOptions, SchemaField } from '@gentics/mesh-models';
 
 export interface MeshSchemaListParams extends PagingOptions {
     schemaName?: string;
@@ -13,7 +13,8 @@ export interface MeshSchemaListResponse {
 
 export interface SchemaContainer {
     name: string;
-    elements: Array<SchemaElement>;
+    elements: SchemaElement[];
+    fields: SchemaField[];
 }
 
 export interface SchemaElement {

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/providers/mesh-browser-loader.service.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/providers/mesh-browser-loader.service.ts
@@ -113,4 +113,17 @@ export class MeshBrowserLoaderService {
         return response.data;
     }
 
+    public async getDefaultLanguage(): Promise<Language>{
+        // const response = await this.meshClient.language.getDefault();
+        // return response;
+
+        //todo: replace with real call
+        return {
+            uuid: 'b104a4da343a4a888818a410611b09e5',
+            name: 'English',
+            nativeName: 'English',
+            languageTag: 'en',
+        }
+    }
+
 }

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/providers/mesh-browser-loader.service.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/providers/mesh-browser-loader.service.ts
@@ -4,7 +4,6 @@ import { MeshRestClientService } from '@gentics/mesh-rest-client-angular';
 import { MeshSchemaListParams, MeshSchemaListResponse, SchemaContainer, SchemaElement } from '../models/mesh-browser-models';
 
 
-
 @Injectable()
 export class MeshBrowserLoaderService {
 
@@ -20,7 +19,7 @@ export class MeshBrowserLoaderService {
         return projectList.data;
     }
 
-    public async getBranches(project: string): Promise<Array<BranchReference>> {
+    public async getBranches(project: string): Promise<BranchReference[]> {
         const branchList = await this.meshClient.branches.list(project);
         return branchList.data;
     }
@@ -45,7 +44,7 @@ export class MeshBrowserLoaderService {
         }
     }
 
-    public async listProjectSchemas(project: string): Promise<Array<SchemaContainer>> {
+    public async listProjectSchemas(project: string): Promise<SchemaContainer[]> {
         const response = await this.meshClient.projects.listSchemas(project);
 
         return response.data.map(schemaItem => {
@@ -61,7 +60,7 @@ export class MeshBrowserLoaderService {
         return response.data.find(schemaItem => schemaItem.name === project).rootNode.uuid;
     }
 
-    public async listNodeChildrenForSchema(project: string, params: MeshSchemaListParams, branchUuid?: string): Promise<Array<SchemaElement>>  {
+    public async listNodeChildrenForSchema(project: string, params: MeshSchemaListParams, branchUuid?: string): Promise<SchemaElement[]>  {
         const response = await this.meshClient.graphql(project, {
             query: `
                 query ($page: Long, $perPage: Long, $schemaName: String, $nodeUuid: String, $lang: [String]) {

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/providers/mesh-browser-loader.service.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/providers/mesh-browser-loader.service.ts
@@ -44,6 +44,19 @@ export class MeshBrowserLoaderService {
         }
     }
 
+    public async getProjectRootNodeUuid(project: string): Promise<string> {
+        const response = await this.meshClient.graphql(project, {
+            query: `
+                {
+                    project{ rootNode {uuid}}
+                }
+            `,
+        });
+
+        return response.data.project.rootNode.uuid;
+    }
+
+
     public async listProjectSchemas(project: string): Promise<SchemaContainer[]> {
         const response = await this.meshClient.projects.listSchemas(project);
 

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/providers/mesh-browser-loader.service.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/providers/mesh-browser-loader.service.ts
@@ -117,7 +117,7 @@ export class MeshBrowserLoaderService {
         // const response = await this.meshClient.language.getDefault();
         // return response;
 
-        //todo: replace with real call
+        // todo: replace with real call
         return {
             uuid: 'b104a4da343a4a888818a410611b09e5',
             name: 'English',

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/providers/mesh-browser-loader.service.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/providers/mesh-browser-loader.service.ts
@@ -63,6 +63,7 @@ export class MeshBrowserLoaderService {
         return response.data.map(schemaItem => {
             return {
                 name: schemaItem.name,
+                fields: schemaItem.fields,
             } as SchemaContainer
         });
     }
@@ -115,10 +116,30 @@ export class MeshBrowserLoaderService {
         return response.data.node?.children?.elements
     }
 
+    public async getSchemaNameForNode(project: string, params: MeshSchemaListParams): Promise<string>  {
+        const response = await this.meshClient.graphql(project, {
+            query: `
+                query($nodeUuid: String) {
+                    node(uuid: $nodeUuid) { 
+                        uuid
+                        schema {
+                            name
+                        }
+                    }
+                }
+            `,
+            variables: params,
+        });
+
+        return response.data?.node?.schema?.name;
+    }
+
+
     public async getNodeByUuid(project: string, uuid: string, params?: NodeLoadOptions): Promise<NodeResponse> {
         const response = await this.meshClient.nodes.get(project, uuid, params);
         return response;
     }
+
 
     public async getAllLanguages(): Promise<Language[]>{
         const response = await this.meshClient.language.list();

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/providers/mesh-browser-loader.service.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/providers/mesh-browser-loader.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { BranchReference, NodeLoadOptions, NodeResponse, ProjectResponse, UserResponse } from '@gentics/mesh-models';
+import { BranchReference, Language, NodeLoadOptions, NodeResponse, ProjectResponse, UserResponse } from '@gentics/mesh-models';
 import { MeshRestClientService } from '@gentics/mesh-rest-client-angular';
 import { MeshSchemaListParams, MeshSchemaListResponse, SchemaContainer, SchemaElement } from '../models/mesh-browser-models';
 
@@ -106,6 +106,12 @@ export class MeshBrowserLoaderService {
     public async getNodeByUuid(project: string, uuid: string, params?: NodeLoadOptions): Promise<NodeResponse> {
         const response = await this.meshClient.nodes.get(project, uuid, params);
         return response;
+    }
+
+    public async getAllLanguages(): Promise<Language[]>{
+        const response = await this.meshClient.language.list();
+
+        return response.data;
     }
 
 }

--- a/cms-ui/apps/admin-ui/src/app/features/mesh-browser/providers/mesh-browser-navigator.service.ts
+++ b/cms-ui/apps/admin-ui/src/app/features/mesh-browser/providers/mesh-browser-navigator.service.ts
@@ -12,7 +12,6 @@ import {
     NavigationEntry,
 } from '../models/mesh-browser-models';
 
-
 @Injectable()
 export class MeshBrowserNavigatorService {
     constructor(
@@ -20,7 +19,6 @@ export class MeshBrowserNavigatorService {
         protected breadcrumbService: BreadcrumbsService,
         protected router: Router,
     ) {}
-
 
     public handleNavigation(
         route: ActivatedRoute,
@@ -31,49 +29,39 @@ export class MeshBrowserNavigatorService {
         currentLanguage: string,
     ): void {
         this.router.navigate(
-            [
-                '/' + AdminUIModuleRoutes.MESH_BROWSER,
+            this.getRouteCommand(
                 selectedRepositoryId,
-                {
-                    outlets: {
-                        [ROUTE_MESH_BROWSER_OUTLET]: [
-                            'list',
-                            currentProject,
-                            currentBranchUuid,
-                            parentNodeUuid,
-                            currentLanguage,
-                        ],
-                    },
-                },
-            ],
+                currentProject,
+                currentBranchUuid,
+                parentNodeUuid,
+                currentLanguage,
+            ),
             { relativeTo: route },
         );
     }
 
-
-    public getRouteCommand(
+    private getRouteCommand(
         selectedRepositoryId: number,
         currentProject: string,
         currentBranchUuid: string,
         parentNodeUuid: string,
         currentLanguage: string,
     ): any[] {
-        const command =
-            [
-                '/' + AdminUIModuleRoutes.MESH_BROWSER,
-                selectedRepositoryId,
-                {
-                    outlets: {
-                        [ROUTE_MESH_BROWSER_OUTLET]: [
-                            'list',
-                            currentProject,
-                            currentBranchUuid,
-                            parentNodeUuid ?? 'undefined',
-                            currentLanguage,
-                        ],
-                    },
+        const command = [
+            '/' + AdminUIModuleRoutes.MESH_BROWSER,
+            selectedRepositoryId,
+            {
+                outlets: {
+                    [ROUTE_MESH_BROWSER_OUTLET]: [
+                        'list',
+                        currentProject,
+                        currentBranchUuid,
+                        parentNodeUuid ?? 'undefined',
+                        currentLanguage,
+                    ],
                 },
-            ];
+            },
+        ];
 
         return command;
     }
@@ -83,7 +71,6 @@ export class MeshBrowserNavigatorService {
             relativeTo: route,
         });
     }
-
 
     public async handleBreadcrumbNavigation(
         selectedRepositoryId: number,

--- a/cms-ui/apps/admin-ui/src/app/mesh/components/copy-value/copy-value.component.html
+++ b/cms-ui/apps/admin-ui/src/app/mesh/components/copy-value/copy-value.component.html
@@ -4,6 +4,6 @@
         <div class="content">{{ value }}</div>
     </div>
     <button class="copy-button" [disabled]="disabled" [title]="'shared.copy' | i18n" (click)="copyToClipboard()">
-        <icon>content_copy</icon>
+        <icon>{{ icon }}</icon>
     </button>
 </div>

--- a/cms-ui/apps/admin-ui/src/app/mesh/components/copy-value/copy-value.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/mesh/components/copy-value/copy-value.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, Input, Output, EventEmitter } from '@angular/core';
+import { Component, ChangeDetectionStrategy, Input, Output, EventEmitter, ChangeDetectorRef } from '@angular/core';
 import { BaseComponent, cancelEvent } from '@gentics/ui-core';
 
 @Component({
@@ -11,6 +11,8 @@ export class CopyValueComponent extends BaseComponent {
 
     public readonly cancelEvent = cancelEvent;
 
+    public icon = 'content_copy';
+
     @Input()
     public label: string;
 
@@ -20,10 +22,16 @@ export class CopyValueComponent extends BaseComponent {
     @Output()
     public copy = new EventEmitter<void | Error>();
 
+    constructor(protected changeDetector: ChangeDetectorRef) {
+        super(changeDetector);
+    }
+
     async copyToClipboard(): Promise<void> {
         try {
             await navigator.clipboard.writeText(this.value);
             this.copy.emit();
+            this.icon = 'checked';
+            this.changeDetector.markForCheck()
         } catch (err) {
             this.copy.emit(err);
         }

--- a/cms-ui/apps/admin-ui/src/app/mesh/components/copy-value/copy-value.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/mesh/components/copy-value/copy-value.component.ts
@@ -1,4 +1,11 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    EventEmitter,
+    Input,
+    Output,
+} from '@angular/core';
 import { BaseComponent, cancelEvent } from '@gentics/ui-core';
 
 @Component({
@@ -7,9 +14,11 @@ import { BaseComponent, cancelEvent } from '@gentics/ui-core';
     styleUrls: ['./copy-value.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CopyValueComponent extends BaseComponent  {
-
+export class CopyValueComponent extends BaseComponent {
     public readonly cancelEvent = cancelEvent;
+
+    @Input()
+    public animate: false;
 
     public icon = 'content_copy';
 
@@ -30,10 +39,21 @@ export class CopyValueComponent extends BaseComponent  {
         try {
             await navigator.clipboard.writeText(this.value);
             this.copy.emit();
-            this.icon = 'checked';
-            this.changeDetector.markForCheck()
+            if (this.animate) {
+                this.animateCopy(1)
+            }
         } catch (err) {
             this.copy.emit(err);
         }
+    }
+
+    private animateCopy(seconds: number): void {
+        this.icon = 'checked';
+        this.changeDetector.markForCheck();
+
+        setTimeout(() => {
+            this.icon = 'content_copy';
+            this.changeDetector.markForCheck();
+        }, 1000 * seconds);
     }
 }

--- a/cms-ui/apps/admin-ui/src/app/mesh/components/copy-value/copy-value.component.ts
+++ b/cms-ui/apps/admin-ui/src/app/mesh/components/copy-value/copy-value.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, Input, Output, EventEmitter, ChangeDetectorRef } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, Output } from '@angular/core';
 import { BaseComponent, cancelEvent } from '@gentics/ui-core';
 
 @Component({
@@ -7,7 +7,7 @@ import { BaseComponent, cancelEvent } from '@gentics/ui-core';
     styleUrls: ['./copy-value.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CopyValueComponent extends BaseComponent {
+export class CopyValueComponent extends BaseComponent  {
 
     public readonly cancelEvent = cancelEvent;
 

--- a/cms-ui/apps/admin-ui/src/app/state/app-state.ts
+++ b/cms-ui/apps/admin-ui/src/app/state/app-state.ts
@@ -3,6 +3,7 @@ import { EntityStateModel } from './entity/entity.state';
 import { FeaturesStateModel } from './features/features.state';
 import { LoadingStateModel } from './loading/loading.state';
 import { MaintenanceModeStateModel } from './maintenance-mode/maintenance-mode.state';
+import { MeshStateModel } from './mesh/mesh.state';
 import { MessageStateModel } from './messages/message.state';
 import { PermissionsStateModel } from './permissions/permissions.state';
 import { UIStateModel } from './ui/ui.state';
@@ -28,4 +29,5 @@ export interface AppState {
     messages: MessageStateModel;
     permissions: PermissionsStateModel;
     ui: UIStateModel;
+    mesh: MeshStateModel;
 }

--- a/cms-ui/apps/admin-ui/src/app/state/index.ts
+++ b/cms-ui/apps/admin-ui/src/app/state/index.ts
@@ -18,5 +18,7 @@ export * from './permissions/permissions.state';
 export * from './providers/app-state/app-state.service';
 export * from './ui/ui.actions';
 export * from './ui/ui.state';
+export * from './mesh/mesh.actions';
+export * from './mesh/mesh.state';
 export * from './utils';
 export { StateModule };

--- a/cms-ui/apps/admin-ui/src/app/state/mesh/mesh.actions.ts
+++ b/cms-ui/apps/admin-ui/src/app/state/mesh/mesh.actions.ts
@@ -1,0 +1,13 @@
+import { SchemaContainer } from '@admin-ui/features/mesh-browser/models/mesh-browser-models';
+import { AppState } from '../app-state';
+import { ActionDeclaration } from '../utils';
+
+
+const MESH: keyof AppState = 'mesh';
+
+
+@ActionDeclaration(MESH)
+export class SchemasLoaded {
+    static readonly TYPE = 'SchemaLoaded';
+    constructor(public schemas: SchemaContainer[]) {}
+}

--- a/cms-ui/apps/admin-ui/src/app/state/mesh/mesh.state.ts
+++ b/cms-ui/apps/admin-ui/src/app/state/mesh/mesh.state.ts
@@ -1,0 +1,31 @@
+import { SchemaContainer } from '@admin-ui/features/mesh-browser/models/mesh-browser-models';
+import { Injectable } from '@angular/core';
+import { StateContext } from '@ngxs/store';
+import { patch } from '@ngxs/store/operators';
+import { ActionDefinition, AppStateBranch, defineInitialState } from '../utils/state-utils';
+import { SchemasLoaded } from './mesh.actions';
+
+
+export interface MeshStateModel {
+    schemas: SchemaContainer[];
+}
+
+
+export const INITIAL_MESH_STATE = defineInitialState<MeshStateModel>({
+    schemas: [],
+});
+
+@AppStateBranch({
+    name: 'mesh',
+    defaults: INITIAL_MESH_STATE,
+})
+@Injectable()
+export class MeshStateModule {
+
+    @ActionDefinition(SchemasLoaded)
+    setSchemas(ctx: StateContext<MeshStateModel>, action: SchemasLoaded): void {
+        ctx.setState(patch({
+            schemas: action.schemas,
+        }));
+    }
+}

--- a/cms-ui/apps/admin-ui/src/app/state/state.module.ts
+++ b/cms-ui/apps/admin-ui/src/app/state/state.module.ts
@@ -12,6 +12,7 @@ import { PermissionsStateModule } from './permissions/permissions.state';
 import { AppStateService } from './providers/app-state/app-state.service';
 import { assembleReduxDevToolsConfig, OPTIONS_CONFIG } from './state-store.config';
 import { UIStateModule } from './ui/ui.state';
+import { MeshStateModule } from './mesh/mesh.state';
 
 /** Contains all ngxs state modules. */
 export const STATE_MODULES = [
@@ -23,6 +24,7 @@ export const STATE_MODULES = [
     MessageStateModule,
     PermissionsStateModule,
     UIStateModule,
+    MeshStateModule,
 ];
 
 @NgModule({

--- a/cms-ui/libs/mesh-models/src/lib/index.ts
+++ b/cms-ui/libs/mesh-models/src/lib/index.ts
@@ -18,3 +18,4 @@ export * from './schemas';
 export * from './server';
 export * from './tags';
 export * from './users';
+export * from './language';

--- a/cms-ui/libs/mesh-models/src/lib/language.ts
+++ b/cms-ui/libs/mesh-models/src/lib/language.ts
@@ -1,0 +1,10 @@
+
+/**
+ * The retrieved Mesh language
+ */
+export interface Language {
+    uuid: string;
+    name: string;
+    nativeName: string;
+    languageTag: string;
+}

--- a/cms-ui/libs/mesh-rest-client-angular/src/lib/mesh-rest-client.service.ts
+++ b/cms-ui/libs/mesh-rest-client-angular/src/lib/mesh-rest-client.service.ts
@@ -7,6 +7,7 @@ import {
     MeshCoordinatorAPI,
     MeshGraphQLAPI,
     MeshGroupAPI,
+    MeshLanguageAPI,
     MeshMicroschemaAPI,
     MeshNodeAPI,
     MeshPermissionAPI,
@@ -126,5 +127,9 @@ export class MeshRestClientService {
 
     get graphql(): MeshGraphQLAPI {
         return this.client.graphql;
+    }
+
+    get language(): MeshLanguageAPI {
+        return this.client.language;
     }
 }

--- a/cms-ui/libs/mesh-rest-client/src/lib/client.ts
+++ b/cms-ui/libs/mesh-rest-client/src/lib/client.ts
@@ -8,6 +8,7 @@ import {
     MeshCoordinatorAPI,
     MeshGraphQLAPI,
     MeshGroupAPI,
+    MeshLanguageAPI,
     MeshMicroschemaAPI,
     MeshNodeAPI,
     MeshPermissionAPI,
@@ -287,4 +288,10 @@ export class MeshRestClient {
     } as const;
 
     public graphql: MeshGraphQLAPI = (project, body, params) => this.executeJsonRequest(POST, `/${project}/graphql`, body, params);
+
+    public language: MeshLanguageAPI = {
+        list: () => this.executeJsonRequest(GET, '/languages'),
+        getDefault: () => this.executeJsonRequest(GET, '/languages'),
+    } as const;
+
 }

--- a/cms-ui/libs/mesh-rest-client/src/lib/models.ts
+++ b/cms-ui/libs/mesh-rest-client/src/lib/models.ts
@@ -239,7 +239,6 @@ export interface MeshNodeAPI {
     get(project: string, uuid: string, prams?: NodeLoadOptions): Promise<NodeResponse>;
     update(project: string, uuid: string, body: NodeUpdateRequest): Promise<NodeResponse>;
     delete(project: string, uuid: string, params?: NodeDeleteOptions): Promise<GenericMessageResponse>;
-    // todo: check this (has been moved?)
     deleteLanguage(project: string, uuid: string, language: string): Promise<GenericMessageResponse>;
     children(project: string, uuid: string, params?: NodeListOptions): Promise<NodeListResponse>;
     versions(project: string, uuid: string): Promise<NodeVersionsResponse>;

--- a/cms-ui/libs/mesh-rest-client/src/lib/models.ts
+++ b/cms-ui/libs/mesh-rest-client/src/lib/models.ts
@@ -82,6 +82,8 @@ import {
     TagNodeListOptions,
     NodeLoadOptions,
     LoginRequest,
+    Language,
+    ListResponse,
 } from '@gentics/mesh-models';
 
 export interface MeshClientDriver {
@@ -237,7 +239,7 @@ export interface MeshNodeAPI {
     get(project: string, uuid: string, prams?: NodeLoadOptions): Promise<NodeResponse>;
     update(project: string, uuid: string, body: NodeUpdateRequest): Promise<NodeResponse>;
     delete(project: string, uuid: string, params?: NodeDeleteOptions): Promise<GenericMessageResponse>;
-
+    // todo: check this (has been moved?)
     deleteLanguage(project: string, uuid: string, language: string): Promise<GenericMessageResponse>;
     children(project: string, uuid: string, params?: NodeListOptions): Promise<NodeListResponse>;
     versions(project: string, uuid: string): Promise<NodeVersionsResponse>;
@@ -299,3 +301,8 @@ export interface MeshPluginAPI {
 }
 
 export type MeshGraphQLAPI = (project: string, body: GraphQLRequest, params?: GraphQLOptions) => Promise<GraphQLResponse>;
+
+export interface MeshLanguageAPI {
+    getDefault(): Promise<Language>;
+    list(): Promise<ListResponse<Language>>;
+}


### PR DESCRIPTION
Issue: https://jira.gentics.com/browse/GPU-1384

## Editor Improvements
- show empty schema fields of node (not included in the api response)
- schema fields must be retrieved 
- Use state to cache schema list 
- Display different field types properly
- Add UUID and add copy component

## General
- Fix schema sorting
- Fix I18N and add missing translations
- Handle case if all schemas are empty (no nodes)

![Screenshot from 2023-12-21 10-41-51](https://github.com/gentics/cms-oss/assets/3427782/be48de90-6840-4b53-80dc-6158ca4e19f4)
