### PR TITLE
Fix permission check for "publish" permission to always consider the

### DIFF
--- a/cms-core/src/main/java/com/gentics/contentnode/rest/resource/impl/PageResourceImpl.java
+++ b/cms-core/src/main/java/com/gentics/contentnode/rest/resource/impl/PageResourceImpl.java
@@ -752,7 +752,12 @@ public class PageResourceImpl extends AuthenticatedContentNodeResource implement
 		try (AutoCommit cmt = new AutoCommit()) {
 			// first get the page and lock it (for checking the permission to
 			// save)
-			page = getLockedPage(id, PermHandler.ObjectPermission.edit);
+			if (request.isClearOfflineAt() || request.isClearPublishAt()) {
+				// clearing offlineAt or publishAt currently requires the publish permission (since that cannot be queued)
+				page = getLockedPage(id, PermHandler.ObjectPermission.edit, PermHandler.ObjectPermission.publish);
+			} else {
+				page = getLockedPage(id, PermHandler.ObjectPermission.edit);
+			}
 
 			// Transform the rest PageSaveRequest into a rest page
 			com.gentics.contentnode.rest.model.Page restPage = request.getPage();
@@ -859,15 +864,11 @@ public class PageResourceImpl extends AuthenticatedContentNodeResource implement
 			// save the page
 			page.save(request.isCreateVersion());
 
-			if (t.canPublish(page)) {
-				if (request.isClearPublishAt()) {
-					page.clearTimePub();
-				}
-				if (request.isClearOfflineAt()) {
-					page.clearTimeOff();
-				}
-			} else {
-				// TODO if the user has no publish permission, should we queue the request to clear the time_pub/time_off (currently, this request cannot be stored in the DB)
+			if (request.isClearPublishAt()) {
+				page.clearTimePub();
+			}
+			if (request.isClearOfflineAt()) {
+				page.clearTimeOff();
 			}
 
 			// unlock the page if requested

--- a/cms-core/src/test/java/com/gentics/contentnode/tests/utils/Builder.java
+++ b/cms-core/src/test/java/com/gentics/contentnode/tests/utils/Builder.java
@@ -29,6 +29,10 @@ public class Builder<T extends NodeObject> {
 
 	protected int publishAt = 0;
 
+	protected boolean takeOffline = false;
+
+	protected int takeOfflineAt = 0;
+
 	protected boolean unlock = false;
 
 	/**
@@ -116,6 +120,25 @@ public class Builder<T extends NodeObject> {
 	}
 
 	/**
+	 * Enable taking the object offline (if it can be published)
+	 * @return fluent API
+	 */
+	public Builder<T> takeOffline() {
+		return takeOffline(0);
+	}
+
+	/**
+	 * Enable taking the object offline (if it can be published)
+	 * @param timestamp offline timestamp
+	 * @return fluent API
+	 */
+	public Builder<T> takeOffline(int timestamp) {
+		this.takeOffline = true;
+		this.takeOfflineAt = timestamp;
+		return this;
+	}
+
+	/**
 	 * Disable publishing the object (if it can be published), which is the default
 	 * @return fluent API
 	 */
@@ -184,6 +207,10 @@ public class Builder<T extends NodeObject> {
 
 			if (publish && modifiedObject instanceof PublishableNodeObject) {
 				((PublishableNodeObject) modifiedObject).publish(publishAt, false);
+			}
+
+			if (takeOffline && modifiedObject instanceof PublishableNodeObject) {
+				((PublishableNodeObject) modifiedObject).takeOffline(takeOfflineAt);
 			}
 
 			if (unlock) {

--- a/cms-oss-changelog/src/changelog/entries/2024/02/7687.SUP-16344.bugfix
+++ b/cms-oss-changelog/src/changelog/entries/2024/02/7687.SUP-16344.bugfix
@@ -1,0 +1,2 @@
+If removing a "publish at" or "offline at" time was denied due to insufficient permissions, the request still succeeded and no
+appropriate message was shown to the user. This has been fixed.


### PR DESCRIPTION
object's own node/channel.
Fix request to clear publishAt of offlineAt to properly response with "no permission" if the user is lacking "publish" permission.