### PR TITLE
Move publishing npm packages from maven build to extra stage (after

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -428,5 +428,18 @@ spec:
                 }
             }
         }
+
+        stage("Publish NPM Packages") {
+            when {
+                expression {
+                    return params.runReleaseBuild && params.deploy
+                }
+            }
+
+            dir(path: 'cms-ui') {
+                // Publish the pacakges to npm repository
+                sh "npm run nx -- release publish --projects=tag:publish --output-style=static"
+            }
+        }
     }
 }

--- a/cms-ui/pom.xml
+++ b/cms-ui/pom.xml
@@ -276,29 +276,6 @@
                             </target>
                         </configuration>
                     </execution>
-
-                    <execution>
-                        <?m2e ignore?>
-                        <id>npm publish</id>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-
-                        <phase>deploy</phase>
-
-                        <configuration>
-                            <target name="Publish UI Modules" unless="${ui.skip.publish}">
-                                <!-- Ppublish all publishable projects -->
-                                <exec
-                                    dir="${npm.workingDirectory}"
-                                    executable="${nodejs.npm.bin}"
-                                    failonerror="true"
-                                >
-                                    <arg line="run nx -- release publish --projects=tag:publish --output-style=static" />
-                                </exec>
-                            </target>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
 


### PR DESCRIPTION
everything else), because npm packages cannot be republished (but need to be removed manually), when the release build has to be repeated