### PR TITLE
SUP-18792 Keep the item count after the spontaneous reload

### DIFF
--- a/cms-oss-changelog/src/changelog/entries/2025/07/8354.SUP-18792.bugfix
+++ b/cms-oss-changelog/src/changelog/entries/2025/07/8354.SUP-18792.bugfix
@@ -1,0 +1,1 @@
+Editor: Now the pagination and items-per-page count are kept after doing various actions with the distinct item.

--- a/cms-ui/apps/editor-ui/src/app/state/providers/folder-actions/folder-actions.service.ts
+++ b/cms-ui/apps/editor-ui/src/app/state/providers/folder-actions/folder-actions.service.ts
@@ -651,7 +651,7 @@ export class FolderActionsService {
         const languages = this.appState.now.entities.language;
         const itemInfo: ItemsInfo = folderState[`${type}s` as FolderItemTypePlural];
         const fetchAll = itemInfo.fetchAll;
-        const maxItems = fetchAll ? -1 : 10;
+        const maxItems = fetchAll ? -1 : itemInfo.itemsPerPage;
         const search = folderState.searchTerm;
         const recursive = search !== '';
         const parentId = folderState.activeFolder;


### PR DESCRIPTION
Exists in 6.0 as well.