### PR TITLE
SUP-20110: Mesh dep update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 		<!-- dd.MM.YYYY -->
 		<alohaeditor.date>14.07.2026</alohaeditor.date>
 		<!-- Dependency to Mesh Client Version. Tested Mesh Server Version is defined with com.gentics.contentnode.testutils.mesh.MeshContext.TESTED_MESH_VERSION -->
-		<mesh.version>3.2.12</mesh.version>
+		<mesh.version>3.2.13</mesh.version>
 
 		<!-- When updating the dependency to jersey, also update the dependencies to jetty and jackson accordingly -->
 		<jersey.version>3.1.10</jersey.version>


### PR DESCRIPTION
No changelog because of no actual change aside of CMP component update, which is already documented.