### PR TITLE
PoC: streaming response in ProxyResource

### DIFF
--- a/cms-core/src/main/java/com/gentics/contentnode/rest/resource/impl/proxy/ProxyResource.java
+++ b/cms-core/src/main/java/com/gentics/contentnode/rest/resource/impl/proxy/ProxyResource.java
@@ -25,6 +25,7 @@ import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.ResponseBuilder;
 import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.core.StreamingOutput;
 import jakarta.ws.rs.core.UriInfo;
 
 import org.apache.commons.httpclient.Header;
@@ -399,6 +400,33 @@ public class ProxyResource {
 			}
 			responseBuilder.header(name, header.getValue());
 		}
-		return responseBuilder.entity(method.getResponseBodyAsStream()).build();
+
+		responseBuilder.header("X-Proxy-Streaming", "1");
+
+		InputStream responseBodyStream = method.getResponseBodyAsStream();
+		if (responseBodyStream == null) {
+			method.releaseConnection();
+			return responseBuilder.build();
+		}
+
+		StreamingOutput streamingBody = output -> {
+			try {
+				byte[] buffer = new byte[8192];
+				int read;
+				while ((read = responseBodyStream.read(buffer)) >= 0) {
+					if (read > 0) {
+						output.write(buffer, 0, read);
+						output.flush();
+					}
+				}
+			} finally {
+				try {
+					responseBodyStream.close();
+				} catch (IOException ignored) {
+				}
+				method.releaseConnection();
+			}
+		};
+		return responseBuilder.entity(streamingBody).build();
 	}
 }


### PR DESCRIPTION
Add streaming output for response body in ProxyResource.

Change vs. stock: forward() returns a StreamingOutput that copies the upstream response with a flush() after every read instead of handing Jersey the raw InputStream (which is copied without any flush, so the bytes sit in Jetty's 32KB output buffer until the response completes). With jersey.config.server.contentLength.buffer=0 active, each flush goes straight to the socket, so proxied responses (GenAIx generations) stream live and nginx's proxy_read_timeout is reset per frame. Also releases the commons-httpclient connection when the copy ends (stock code leaked it) and adds an X-Proxy-Streaming marker header so the patch's presence is verifiable.